### PR TITLE
Use UUIDs for things rather than player usernames.

### DIFF
--- a/src/no/runsafe/worldguardbridge/IRegionControl.java
+++ b/src/no/runsafe/worldguardbridge/IRegionControl.java
@@ -27,7 +27,7 @@ public interface IRegionControl
 
 	List<String> getApplicableRegions(IPlayer player);
 
-	Map<String, Set<String>> getAllRegionsWithOwnersInWorld(IWorld world);
+	Map<String, Set<IPlayer>> getAllRegionsWithOwnersInWorld(IWorld world);
 
 	ILocation getRegionLocation(IWorld world, String name);
 

--- a/src/no/runsafe/worldguardbridge/IRegionControl.java
+++ b/src/no/runsafe/worldguardbridge/IRegionControl.java
@@ -45,6 +45,8 @@ public interface IRegionControl
 
 	List<String> getOwnedRegions(IPlayer player, IWorld world);
 
+	List<String> getMemberRegions(IPlayer player, IWorld world);
+
 	List<String> getRegionsInWorld(IWorld world);
 
 	Map<String, Rectangle2D> getRegionRectanglesInWorld(IWorld world);

--- a/src/no/runsafe/worldguardbridge/IRegionControl.java
+++ b/src/no/runsafe/worldguardbridge/IRegionControl.java
@@ -9,6 +9,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 public interface IRegionControl
 {
@@ -32,7 +33,11 @@ public interface IRegionControl
 
 	Set<String> getOwners(IWorld world, String name);
 
+	Set<UUID> getOwnerUniqueIds(IWorld world, String name);
+
 	Set<String> getMembers(IWorld world, String name);
+
+	Set<UUID> getMemberUniqueIds(IWorld world, String name);
 
 	List<String> getOwnedRegions(IPlayer player, IWorld world);
 

--- a/src/no/runsafe/worldguardbridge/IRegionControl.java
+++ b/src/no/runsafe/worldguardbridge/IRegionControl.java
@@ -35,9 +35,13 @@ public interface IRegionControl
 
 	Set<UUID> getOwnerUniqueIds(IWorld world, String name);
 
+	Set<IPlayer> getOwnerPlayers(IWorld world, String name);
+
 	Set<String> getMembers(IWorld world, String name);
 
 	Set<UUID> getMemberUniqueIds(IWorld world, String name);
+
+	Set<IPlayer> getMemberPlayers(IWorld world, String name);
 
 	List<String> getOwnedRegions(IPlayer player, IWorld world);
 

--- a/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
+++ b/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
@@ -151,13 +151,13 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 	}
 
 	@Override
-	public Map<String, Set<String>> getAllRegionsWithOwnersInWorld(IWorld world)
+	public Map<String, Set<IPlayer>> getAllRegionsWithOwnersInWorld(IWorld world)
 	{
-		HashMap<String, Set<String>> result = new HashMap<String, Set<String>>();
+		HashMap<String, Set<IPlayer>> result = new HashMap<String, Set<IPlayer>>();
 		RegionManager regionManager = worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world));
 		Map<String, ProtectedRegion> regions = regionManager.getRegions();
 		for (String region : regions.keySet())
-			result.put(region, regions.get(region).getOwners().getPlayers());
+			result.put(region, getOwnerPlayers(world, region));
 		return result;
 	}
 

--- a/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
+++ b/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
@@ -200,8 +200,9 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 		RegionManager regionManager = worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world));
 		ArrayList<String> regions = new ArrayList<String>();
 		Map<String, ProtectedRegion> regionSet = regionManager.getRegions();
+		UUID playerUUID = player.getUniqueId();
 		for (String region : regionSet.keySet())
-			if (regionSet.get(region).getOwners().contains(player.getName()))
+			if (regionSet.get(region).getOwners().contains(playerUUID))
 				regions.add(region);
 		return regions;
 	}
@@ -272,7 +273,7 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 		BlockVector min = selection.getNativeMinimumPoint().toBlockVector();
 		BlockVector max = selection.getNativeMaximumPoint().toBlockVector();
 		ProtectedRegion region = new ProtectedCuboidRegion(name, min, max);
-		region.getOwners().addPlayer(owner.getName());
+		region.getOwners().addPlayer(owner.getUniqueId());
 		regionManager.addRegion(region);
 		try
 		{
@@ -343,9 +344,9 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 
 		RegionManager regionManager = worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world));
 		DefaultDomain members = regionManager.getRegion(name).getMembers();
-		if (!members.contains(player.getName()))
+		if (!members.contains(player.getUniqueId()))
 		{
-			members.addPlayer(player.getName());
+			members.addPlayer(player.getUniqueId());
 			try
 			{
 				regionManager.save();
@@ -367,9 +368,9 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 
 		RegionManager regionManager = worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world));
 		DefaultDomain members = regionManager.getRegion(name).getMembers();
-		if (members.contains(player.getName()))
+		if (members.contains(player.getUniqueId()))
 		{
-			members.removePlayer(player.getName());
+			members.removePlayer(player.getUniqueId());
 			try
 			{
 				regionManager.save();

--- a/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
+++ b/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
@@ -184,12 +184,30 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 	}
 
 	@Override
+	public Set<UUID> getOwnerUniqueIds(IWorld world, String name)
+	{
+		if (!serverHasWorldGuard())
+			return null;
+
+		return worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world)).getRegion(name).getOwners().getUniqueIds();
+	}
+
+	@Override
 	public Set<String> getMembers(IWorld world, String name)
 	{
 		if (!serverHasWorldGuard())
 			return null;
 
 		return Sets.newHashSet(worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world)).getRegion(name).getMembers().getPlayers());
+	}
+
+	@Override
+	public Set<UUID> getMemberUniqueIds(IWorld world, String name)
+	{
+		if (!serverHasWorldGuard())
+			return null;
+
+		return Sets.newHashSet(worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world)).getRegion(name).getMembers().getUniqueIds());
 	}
 
 	@Override

--- a/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
+++ b/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
@@ -253,6 +253,20 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 	}
 
 	@Override
+	public List<String> getMemberRegions(IPlayer player, IWorld world)
+	{
+		if (world == null || player == null)
+			return null;
+		RegionManager regionManager = worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world));
+		ArrayList<String> regions = new ArrayList<String>();
+		Map<String, ProtectedRegion> regionSet = regionManager.getRegions();
+		for (String region : regionSet.keySet())
+			if (regionSet.get(region).getMembers().contains(player.getUniqueId()))
+				regions.add(region);
+		return regions;
+	}
+
+	@Override
 	public List<String> getRegionsInWorld(IWorld world)
 	{
 		if (world == null)

--- a/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
+++ b/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
@@ -193,6 +193,20 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 	}
 
 	@Override
+	public Set<IPlayer> getOwnerPlayers(IWorld world, String name)
+	{
+		if (!serverHasWorldGuard())
+			return null;
+
+		Set<UUID> owners = getOwnerUniqueIds(world, name);
+		Set<IPlayer> ownerPlayers = new HashSet<IPlayer>();
+		for (UUID playerUUID : owners)
+			ownerPlayers.add(server.getPlayer(playerUUID));
+
+		return ownerPlayers;
+	}
+
+	@Override
 	public Set<String> getMembers(IWorld world, String name)
 	{
 		if (!serverHasWorldGuard())
@@ -208,6 +222,20 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 			return null;
 
 		return Sets.newHashSet(worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world)).getRegion(name).getMembers().getUniqueIds());
+	}
+
+	@Override
+	public Set<IPlayer> getMemberPlayers(IWorld world, String name)
+	{
+		if (!serverHasWorldGuard())
+			return null;
+
+		Set<UUID> owners = getMemberUniqueIds(world, name);
+		Set<IPlayer> memberPlayers = new HashSet<IPlayer>();
+		for (UUID playerUUID : owners)
+			memberPlayers.add(server.getPlayer(playerUUID));
+
+		return memberPlayers;
 	}
 
 	@Override

--- a/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
+++ b/src/no/runsafe/worldguardbridge/WorldGuardInterface.java
@@ -246,9 +246,8 @@ public class WorldGuardInterface implements IPluginEnabled, IRegionControl
 		RegionManager regionManager = worldGuard.getRegionManager((World) ObjectUnwrapper.convert(world));
 		ArrayList<String> regions = new ArrayList<String>();
 		Map<String, ProtectedRegion> regionSet = regionManager.getRegions();
-		UUID playerUUID = player.getUniqueId();
 		for (String region : regionSet.keySet())
-			if (regionSet.get(region).getOwners().contains(playerUUID))
+			if (regionSet.get(region).getOwners().contains(player.getUniqueId()))
 				regions.add(region);
 		return regions;
 	}


### PR DESCRIPTION
Implements methods for getting members and owners from region as a set of UUIDs and a set of IPlayers.

New method to get all regions a player is a member of.